### PR TITLE
Fixed "undefined method `block_size'" issue.

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -18,7 +18,11 @@
 # limitations under the License.
 #
 
+# The block size (1MB)
+block_size = 1048576
+
 # Creates a swap file of the given size and the given path
+
 action :create do
   bash "create swapfile #{new_resource.path}" do
     code "dd if=/dev/zero of=#{new_resource.path} bs=#{block_size} count=#{new_resource.size}"
@@ -65,10 +69,4 @@ action :remove do
     code          "swapoff #{new_resource.path}"
     notifices     :delete, "file[#{new_resource.name}]"
   end
-end
-
-private
-# The block size (1MB)
-def block_size
-  1048576
 end


### PR DESCRIPTION
With Chef 10.X and 11.X I was receiving the following exception:

```
Generated at 2013-02-16 00:11:07 +0000
NoMethodError: swap_file[/swapfile] (RECIPENAME::COOKBOOKNAME line 3) had an error: NoMethodError: undefined method `block_size' for Chef::Resource::Bash
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource.rb:279:in `method_missing'
/root/chef/cookbooks/swap/providers/file.rb:24:in `block (2 levels) in class_from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/dsl/recipe.rb:71:in `instance_eval'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/dsl/recipe.rb:71:in `method_missing'
/root/chef/cookbooks/swap/providers/file.rb:23:in `block in class_from_file'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/provider/lwrp_base.rb:138:in `instance_eval'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/provider/lwrp_base.rb:138:in `block in action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/provider.rb:118:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource.rb:603:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/runner.rb:50:in `run_action'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/runner.rb:82:in `block (2 levels) in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/runner.rb:82:in `each'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/runner.rb:82:in `block in converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection.rb:94:in `block in execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/resource_collection.rb:92:in `execute_each_resource'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/runner.rb:81:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/client.rb:404:in `converge'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/client.rb:469:in `do_run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/client.rb:200:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application.rb:190:in `run_chef_client'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application/solo.rb:239:in `block in run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application/solo.rb:231:in `loop'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application/solo.rb:231:in `run_application'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/lib/chef/application.rb:73:in `run'
/opt/chef/embedded/lib/ruby/gems/1.9.1/gems/chef-11.4.0/bin/chef-solo:25:in `<top (required)>'
/usr/bin/chef-solo:23:in `load'
/usr/bin/chef-solo:23:in `<main>'
```

This pull request makes block_size a variable rather than a method, and defines it above the resource calls.
