### PR TITLE
A few more tweaks to the /etc/fstab file

### DIFF
--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -152,7 +152,7 @@ class Chef
           contents = ::File.readlines(fstab)
           addition = "#{@new_resource.path} swap swap defaults 0 0"
 
-          if contents.any? { |line| line =~ /^#{addition}/ }
+          if contents.any? { |line| line.strip == addition }
             Chef::Log.debug("#{@new_resource} already added to /etc/fstab - skipping")
           else
             Chef::Log.info("#{@new_resource} adding entry to #{fstab} for #{@new_resource.path}")


### PR DESCRIPTION
I think these changes represent the safest, least intrusive means of updating the /etc/fstab with an entry for the newly created swap file.

I ran these changes a number of times against a couple of different fstab files and each time it produce good results.
