### PR TITLE
Add a simple recipe that uses the swap_file LWRP

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,2 @@
+default['swap']['mountpoint'] = '/var/swapfile'
+default['swap']['size'] = (node['memory']['total'].to_i / 1024) * 2

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,7 @@
+# Default recipe to add a swap file
+# Set node['swap']['mountpoint'] and node['swap']['size']
+# Or leave the default '/var/swapfile' and twice the amount of RAM detected
+
+swap_file node['swap']['mountpoint'] do
+  size node['swap']['size']
+end


### PR DESCRIPTION
This recipe creates a swapfile at /var/swapfile of twice the size of the total memory on the node.

Configurable with the `node['swap']['mountpoint']` and `node['swap']['size']` attributes.
