### PR TITLE
Fix compatibility. ':' replaced by '=>'

### DIFF
--- a/resources/file.rb
+++ b/resources/file.rb
@@ -25,6 +25,6 @@ actions :create, :remove
 default_action :create
 
 # Require attributes
-attribute :path, kind_of: String, name_attribute: true
-attribute :size, kind_of: Fixnum, required: true
-attribute :persist, kind_of: [TrueClass, FalseClass], default: false
+attribute :path, :kind_of => String, :name_attribute => true
+attribute :size, :kind_of => Fixnum, :required => true
+attribute :persist, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Cookbook don't work for me because of this error:

```
/tmp/vagrant-cache/chef-solo-1/cookbooks/swap/resources/file.rb:28: syntax error, unexpected ':', expecting $end
attribute :path, kind_of: String, name_attribute: true
```
