### PR TITLE
chef-11-changes

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,0 +1,1 @@
+# Dummy file.

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -25,6 +25,6 @@ actions :create, :remove
 default_action :create
 
 # Require attributes
-attribute :path, kind_of: String, name_attribute: true
-attribute :size, kind_of: Fixnum, required: true
-attribute :persist, kind_of: [TrueClass, FalseClass], default: false
+attribute :path,    :kind_of => String, :name_attribute => true
+attribute :size,    :kind_of => Fixnum, :required => true
+attribute :persist, :kind_of => [TrueClass, FalseClass], :default => false


### PR DESCRIPTION
Add dummy default recipe. Updated resources file.

These were the errors I recieved:
## SyntaxError

compile error
/var/chef/cache/cookbooks/swap/resources/file.rb:28: syntax error, unexpected ':', expecting $end
attribute :path, kind_of: String, name_attribute: true

And after fixing that, I received:
## Chef::Exceptions::RecipeNotFound

could not find recipe default for cookbook swap
