### PR TITLE
Add ChefSpec matchers

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,27 @@ depends 'swap'
 
 Now you can use the LWRP in your cookbook!
 
+ChefSpec matchers
+-----------------
+
+### create_swap_file(path)
+
+Assert that the Chef run creates swap_file.
+
+```ruby
+expect(chef_run).to create_swap_file(path).with(
+  :size => 1024
+)
+```
+
+### remove_swap_file(path)
+
+Assert that the Chef run removes swap_file.
+
+```ruby
+expect(chef_run).to remove_swap_file(path)
+```
+
 
 Contributing
 ------------

--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,11 @@
+if defined?(ChefSpec)
+
+  def create_swap_file(path)
+    ChefSpec::Matchers::ResourceMatcher.new(:swap_file, :create, path)
+  end
+
+  def remove_swap_file(path)
+    ChefSpec::Matchers::ResourceMatcher.new(:swap_file, :remove, path)
+  end
+
+end


### PR DESCRIPTION
Add ChefSpec matchers for the `swap_file` resource.

For example:

``` ruby
expect(chef_run).to create_swap_file(path).with(
  :size => 1024
)
```
