### PR TITLE
add swappiness value setting

### DIFF
--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -189,8 +189,6 @@ class Chef
         sysctl_command = '/sbin/sysctl vm.swappiness=10'
         Chef::Log.info("#{@new_resource} is setting swappiness value using sysctl.")
         shell_out!(sysctl_command)
-
-        end
       end
     end
   end

--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -183,21 +183,13 @@ class Chef
       # Link: https://help.ubuntu.com/community/SwapFaq#What_is_swappiness_and_how_do_I_change_it.3F
       # Link: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Performance_Tuning_Guide/s-memory-tunables.html
       def swappiness
-        proc_command = 'echo 10 > /proc/sys/vm/swappiness'
         Chef::Log.info("#{@new_resource} is setting swappiness value in '/proc/sys/vm/swappiness'")
-        shell_out!(proc_command)
+        ::File.write('/proc/sys/vm/swappiness', '10')
 
-        sysctl = '/etc/sysctl.conf'
-        contents = ::File.readlines(sysctl)
-        addition = 'vm.swappiness = 10'
+        sysctl_command = '/sbin/sysctl vm.swappiness=10'
+        Chef::Log.info("#{@new_resource} is setting swappiness value using sysctl.")
+        shell_out!(sysctl_command)
 
-        if contents.any? { |line| line.strip == addition }
-          Chef::Log.debug("#{@new_resource} already added to /etc/sysctl.conf - skipping")
-        else
-          Chef::Log.info("#{@new_resource} adding entry to #{sysctl} for #{@new_resource.path}")
-
-          contents << "#{addition}\n"
-          ::File.open(sysctl, 'w') { |f| f.write(contents.join('')) }
         end
       end
     end

--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -183,13 +183,13 @@ class Chef
       # Link: https://help.ubuntu.com/community/SwapFaq#What_is_swappiness_and_how_do_I_change_it.3F
       # Link: https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Performance_Tuning_Guide/s-memory-tunables.html
       def swappiness
-        proc_command = "echo 10 > /proc/sys/vm/swappiness"
+        proc_command = 'echo 10 > /proc/sys/vm/swappiness'
         Chef::Log.info("#{@new_resource} is setting swappiness value in '/proc/sys/vm/swappiness'")
         shell_out!(proc_command)
 
-        sysctl = "/etc/sysctl.conf"
+        sysctl = '/etc/sysctl.conf'
         contents = ::File.readlines(sysctl)
-        addition = "vm.swappiness = 10"
+        addition = 'vm.swappiness = 10'
 
         if contents.any? { |line| line.strip == addition }
           Chef::Log.debug("#{@new_resource} already added to /etc/sysctl.conf - skipping")


### PR DESCRIPTION
According to Ubuntu community and Redhat document, A value of swappiness=10 is recommended. Related links are below:
[Ubuntu community recommendation](https://help.ubuntu.com/community/SwapFaq#What_is_swappiness_and_how_do_I_change_it.3F)
[Redhat recommendation](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Performance_Tuning_Guide/s-memory-tunables.html)

I added a `swappiness` function to change the default value from 60 to 10.

One more thing, we can add a new function to handle adding one line into a configuration file without duplication. As both `swappiness` and `persist` function will use the same functionality. Currently those parts are almost the same.  
