### PR TITLE
Using an LWRP by its name directly is no longer supported in Chef 13

### DIFF
--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -26,7 +26,7 @@ class Chef
       provides :swap_file if Chef::Provider.respond_to?(:provides)
 
       def load_current_resource
-        @current_resource ||= Chef::Resource::SwapFile.new(new_resource.name)
+        @current_resource ||= Chef::Resource.SwapFile.new(new_resource.name)
         @current_resource.path(new_resource.path)
         @current_resource.size(new_resource.size)
         @current_resource.persist(!!new_resource.persist)


### PR DESCRIPTION
swap_file[/swapfile0] action create[2015-07-04T07:21:04+00:00] WARN: Using an LWRP by its name (Chef::Resource::SwapFile) directly is no longer supported in Chef 13 and will be removed.  Use Chef::Resource.resource_for_node(node, name) instead.
