### PR TITLE
(WIP) - adding timeout for swapfile creation, fixes #26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the swap cookbook.
 
+## v1.0.1 (tbr)
+
+- now supports a timeout property for create
+
 ## v1.0.0 (2017-02-22)
 
 - This cookbook has been transferred to the Sous Chefs. See sous-chefs.org

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Attribute | Description                                 | Example   | Default
 path      | The path to put the swap file on the system | /mnt/swap |
 size      | The size (in MBs) for the swap file         | 2048      |
 persist   | Persist the swapon                          | true      | false
+timeout   | Timeout for dd/fallocate                    | 600       | 600
 
 ## Installation
 

--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -30,6 +30,7 @@ class Chef
         @current_resource.path(new_resource.path)
         @current_resource.size(new_resource.size)
         @current_resource.persist(!!new_resource.persist)
+        @current_resource.timeout(new_resource.timeout)
         @current_resource
       end
 
@@ -65,7 +66,7 @@ class Chef
       end
 
       def create_swapfile(command)
-        shell_out!(command)
+        shell_out!(command, :timeout => @new_resource.timeout)
         Chef::Log.info("#{@new_resource} Creating empty file at #{@new_resource.path}")
         Chef::Log.debug("#{@new_resource} Empty file at #{@new_resource.path} created using command '#{command}'")
       end

--- a/libraries/swapfile_provider.rb
+++ b/libraries/swapfile_provider.rb
@@ -66,7 +66,7 @@ class Chef
       end
 
       def create_swapfile(command)
-        shell_out!(command, :timeout => @new_resource.timeout)
+        shell_out!(command, timeout: @new_resource.timeout)
         Chef::Log.info("#{@new_resource} Creating empty file at #{@new_resource.path}")
         Chef::Log.debug("#{@new_resource} Empty file at #{@new_resource.path} created using command '#{command}'")
       end

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -25,3 +25,4 @@ default_action :create
 attribute :path,    kind_of: String, name_attribute: true
 attribute :size,    kind_of: Integer
 attribute :persist, kind_of: [TrueClass, FalseClass], default: false
+attribute :timeout, kind_of: Integer, default: 600


### PR DESCRIPTION
adding a property for timeout, with a default of 600, sending this to shellout. 


 - [#26][]


- [x] All tests pass.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable