### PR TITLE
Deprecate cookbook & release 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the swap cookbook.
 
+## v2.2.2 (2018-04-07)
+
+- The swap resource from this cookbook is now shipping as part of Chef 14\. With the inclusion of this resource into Chef itself we are now deprecating this cookbook. It will continue to function for Chef 13 users, but will not be updated.
+
 ## v2.2.1 (2018-03-15)
 
 - Fix #60, incorrect permissions on `set_permissions`

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
+The swap resource from this cookbook is now shipping as part of Chef 14\. With the inclusion of this resource into Chef itself we are now deprecating this cookbook. It will continue to function for Chef 13 users, but will not be updated.
+
 # Swap Cookbook
 
-[![Build Status](https://travis-ci.org/sous-chefs/swap.svg?branch=master)](https://travis-ci.org/sous-chefs/swap)
-[![Cookbook Version](https://img.shields.io/cookbook/v/swap.svg)](https://supermarket.chef.io/cookbooks/swap)
+[![Build Status](https://travis-ci.org/sous-chefs/swap.svg?branch=master)](https://travis-ci.org/sous-chefs/swap) [![Cookbook Version](https://img.shields.io/cookbook/v/swap.svg)](https://supermarket.chef.io/cookbooks/swap)
 
 This cookbook provides resource for easily creating and managing swap files.
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license 'Apache-2.0'
 description 'Manage swap and swapfiles with Chef'
 long_description 'A resource for easily creating a managing swap files ' \
                  'and swap partitions in Chef recipes.'
-version '2.2.1'
+version '2.2.2'
 
 %w(ubuntu debian redhat centos suse opensuse opensuseleap scientific oracle amazon zlinux).each do |os|
   supports os


### PR DESCRIPTION
This resource is now included in Chef itself. 

Signed-off-by: Tim Smith <tsmith@chef.io>